### PR TITLE
docs(recipes): remove extraneous import

### DIFF
--- a/docs/0900|Recipes.md
+++ b/docs/0900|Recipes.md
@@ -3,7 +3,7 @@
 The example below shows a recipe for keeping Homebase React in sync with Firebase. `client.addTransactListener(callback)` lets you listen to every local transaction and send those updates to Firebase. We also need a way to sync Firebase with Homebase React. In this example we create a namespace on Firebase for each user based on their firebase uid and listen to all changes in that namespace. client.` transactSilently(tx)` allows us save changes received from Firebase without triggering our transactListener function and sending those changes back to Firebase endlessly.
 
 ```js
-import { HomebaseProvider, useClient, useEntity, useTransact } from 'homebase-react';
+import { useClient, useEntity, useTransact } from 'homebase-react';
 import firebase from 'firebase/app';
 import debounce from 'lodash/debounce';
 import React from 'react';

--- a/docs/0900|Recipes.md
+++ b/docs/0900|Recipes.md
@@ -3,7 +3,7 @@
 The example below shows a recipe for keeping Homebase React in sync with Firebase. `client.addTransactListener(callback)` lets you listen to every local transaction and send those updates to Firebase. We also need a way to sync Firebase with Homebase React. In this example we create a namespace on Firebase for each user based on their firebase uid and listen to all changes in that namespace. client.` transactSilently(tx)` allows us save changes received from Firebase without triggering our transactListener function and sending those changes back to Firebase endlessly.
 
 ```js
-import { useClient, useEntity, useTransact } from 'homebase-react';
+import { useClient, useEntity} from 'homebase-react';
 import firebase from 'firebase/app';
 import debounce from 'lodash/debounce';
 import React from 'react';

--- a/docs/0900|Recipes.md
+++ b/docs/0900|Recipes.md
@@ -3,7 +3,7 @@
 The example below shows a recipe for keeping Homebase React in sync with Firebase. `client.addTransactListener(callback)` lets you listen to every local transaction and send those updates to Firebase. We also need a way to sync Firebase with Homebase React. In this example we create a namespace on Firebase for each user based on their firebase uid and listen to all changes in that namespace. client.` transactSilently(tx)` allows us save changes received from Firebase without triggering our transactListener function and sending those changes back to Firebase endlessly.
 
 ```js
-import { useClient, useEntity} from 'homebase-react';
+import { useClient, useEntity } from 'homebase-react';
 import firebase from 'firebase/app';
 import debounce from 'lodash/debounce';
 import React from 'react';


### PR DESCRIPTION
## PR Description
Removes unnecessary `HomebaseProvider`, `useTransact` in Firebase recipe.


## PR Checklist

### Testing
- [ ] added relevant test coverage
- [x] no tests needed

### Docs
- [x] added relevant docs 
    - preview them at https://homebase.io/docs/homebase-react/{BRANCH_NAME}/overview
- [ ] updated relevant sections in the README.md
- [ ] updated relevant docstrings in index.d.ts
- [ ] no docs needed

### Typescript
- [ ] added or edited relevant Typescript type declarations
- [z] no type declaration updates needed

## Merging
For maintainers.

To merge, select "Squash and Merge". Then:
  1. Make sure the top commit message follows [Angular Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines),
  2. Delete all other commit messages in the description, but keep any lines designating [co-authors](https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors) so contributors will retain credit for their contributions.
